### PR TITLE
add the onload preview of all movies

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,12 @@
-.App {
-  text-align: center;
-}
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+header {
+  background-color: red;
+  height: 80px;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
+}
+
+h1 {
+  margin-left: 20px;
   color: white;
 }
 
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/src/App.js
+++ b/src/App.js
@@ -1,25 +1,28 @@
-import logo from './logo.svg';
+import React, {Component} from 'react'
 import './App.css';
+import dummyData from './movieData'
+import Movies from './Movies'
 
-function App() {
-  return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
-  );
+class App extends Component {
+  constructor() {
+    super()
+    this.state = {
+      movies: dummyData.movies
+    }
+  }
+
+  render() {
+    return (
+      <body>
+        <header>
+          <h1>Rancid Tomatillos</h1>
+        </header>
+        <main>
+          <Movies movies={this.state.movies}/>
+        </main>
+      </body>
+    );
+  }
 }
 
 export default App;

--- a/src/Movies.css
+++ b/src/Movies.css
@@ -1,0 +1,8 @@
+.movies-container {
+  padding: 20px;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-gap: 10px;
+  background-color:#383838;
+  padding-top: 50px;
+}

--- a/src/Movies.js
+++ b/src/Movies.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import './Movies.css' 
+import Preview from './Preview'
+
+function Movies({movies}) {
+
+  const moviePreviews = movies.map(movie => {
+    return (
+      <Preview 
+        title={movie.title}
+        poster={movie.poster_path}
+        rating={movie.average_rating}
+        date={movie.release_date}
+      />
+    )
+  })
+
+  
+  return (
+    <div className='movies-container'>
+      {moviePreviews}
+    </div>
+  )
+}
+
+export default Movies;

--- a/src/Preview.css
+++ b/src/Preview.css
@@ -1,0 +1,25 @@
+img {
+  height: 350px;
+  display: block;
+}
+
+.poster {
+  position: relative;
+}
+
+.rating {
+	position: absolute;
+	top: 0;
+	left: 0;
+	padding: 10px;
+  background-color: #F0E68C;
+  border-radius: 30px;
+  margin-left: 5px;
+  margin-top: 5px;
+}
+
+h3,
+.date {
+  color: white;
+}
+

--- a/src/Preview.js
+++ b/src/Preview.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import './Preview.css'
+
+function Preview({ title, poster, rating, date }) {
+  return (
+    <div>
+      <div className='poster'>
+        <p className='rating'>{(Math.round(rating * 100)/100).toFixed(2)}</p>
+        <img src={poster}></img>
+      </div>
+      <h3>{title}</h3>
+      <p className='date'>Date Released {date}</p>
+    </div>
+  )
+}
+
+export default Preview

--- a/src/movieData.js
+++ b/src/movieData.js
@@ -1,0 +1,326 @@
+const movieData = {
+  "movies": [
+    {
+      "id": 694919,
+      "poster_path": "https://image.tmdb.org/t/p/original//6CoRTJTmijhBLJTUNoVSUNxZMEI.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//pq0JSpwyT2URytdFG0euztQPAyR.jpg",
+      "title": "Money Plane",
+      "average_rating": 6.666666666666667,
+      "release_date": "2020-09-29"
+    },
+    {
+      "id": 337401,
+      "poster_path": "https://image.tmdb.org/t/p/original//aKx1ARwG55zZ0GpRvU2WrGrCG9o.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//zzWGRw277MNoCs3zhyG3YmYQsXv.jpg",
+      "title": "Mulan",
+      "average_rating": 4.909090909090909,
+      "release_date": "2020-09-04"
+    },
+    {
+      "id": 718444,
+      "poster_path": "https://image.tmdb.org/t/p/original//uOw5JD8IlD546feZ6oxbIjvN66P.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//x4UkhIQuHIJyeeOTdcbZ3t3gBSa.jpg",
+      "title": "Rogue",
+      "average_rating": 5.428571428571429,
+      "release_date": "2020-08-20"
+    },
+    {
+      "id": 539885,
+      "poster_path": "https://image.tmdb.org/t/p/original//qzA87Wf4jo1h8JMk9GilyIYvwsA.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//54yOImQgj8i85u9hxxnaIQBRUuo.jpg",
+      "title": "Ava",
+      "average_rating": 5.111111111111111,
+      "release_date": "2020-07-02"
+    },
+    {
+      "id": 581392,
+      "poster_path": "https://image.tmdb.org/t/p/original//sy6DvAu72kjoseZEjocnm2ZZ09i.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//gEjNlhZhyHeto6Fy5wWy5Uk3A9D.jpg",
+      "title": "Peninsula",
+      "average_rating": 7,
+      "release_date": "2020-07-15"
+    },
+    {
+      "id": 726739,
+      "poster_path": "https://image.tmdb.org/t/p/original//4BgSWFMW2MJ0dT5metLzsRWO7IJ.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//t22fWbzdnThPseipsdpwgdPOPCR.jpg",
+      "title": "Cats & Dogs 3: Paws Unite",
+      "average_rating": 7.4,
+      "release_date": "2020-10-02"
+    },
+    {
+      "id": 627290,
+      "poster_path": "https://image.tmdb.org/t/p/original//irkse1FMm9dWemwlxKJ7RINT9Iy.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//pGqBDYycGWsMYc57sYv5M9GAQoW.jpg",
+      "title": "Antebellum",
+      "average_rating": 6.375,
+      "release_date": "2020-09-02"
+    },
+    {
+      "id": 613504,
+      "poster_path": "https://image.tmdb.org/t/p/original//kiX7UYfOpYrMFSAGbI6j1pFkLzQ.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//r5srC0cqU36n38azFnCyReEksiR.jpg",
+      "title": "After We Collided",
+      "average_rating": 5.25,
+      "release_date": "2020-09-02"
+    },
+    {
+      "id": 659986,
+      "poster_path": "https://image.tmdb.org/t/p/original//gzFatNrw0lhKD5NxaU6zC7S2KjP.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//xUUtcxWC6H48UCrpRwwSPQz69XC.jpg",
+      "title": "The Owners",
+      "average_rating": 5.285714285714286,
+      "release_date": "2020-09-04"
+    },
+    {
+      "id": 632618,
+      "poster_path": "https://image.tmdb.org/t/p/original//sDi6wKgECUjDug2gn4uODSqZ3yC.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//cVdYaAQmd5DZNdo0KFJruz7JpUs.jpg",
+      "title": "The Crimes That Bind",
+      "average_rating": 4.857142857142857,
+      "release_date": "2020-08-20"
+    },
+    {
+      "id": 446893,
+      "poster_path": "https://image.tmdb.org/t/p/original//7W0G3YECgDAfnuiHG91r8WqgIOe.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//qsxhnirlp7y4Ae9bd11oYJSX59j.jpg",
+      "title": "Trolls World Tour",
+      "average_rating": 5.5,
+      "release_date": "2020-03-12"
+    },
+    {
+      "id": 508439,
+      "poster_path": "https://image.tmdb.org/t/p/original//f4aul3FyD3jv3v4bul1IrkWZvzq.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//xFxk4vnirOtUxpOEWgA1MCRfy6J.jpg",
+      "title": "Onward",
+      "average_rating": 6.4,
+      "release_date": "2020-02-29"
+    },
+    {
+      "id": 479259,
+      "poster_path": "https://image.tmdb.org/t/p/original//vQgXwuJrlpzGDI8169tRQRy71Nv.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//wUP0KIAXcRevjjJpoSKT7LLhiaK.jpg",
+      "title": "Lost Girls & Love Hotels",
+      "average_rating": 3.857142857142857,
+      "release_date": "2020-09-18"
+    },
+    {
+      "id": 592350,
+      "poster_path": "https://image.tmdb.org/t/p/original//zGVbrulkupqpbwgiNedkJPyQum4.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//9guoVF7zayiiUq5ulKQpt375VIy.jpg",
+      "title": "My Hero Academia: Heroes Rising",
+      "average_rating": 5,
+      "release_date": "2019-12-20"
+    },
+    {
+      "id": 531876,
+      "poster_path": "https://image.tmdb.org/t/p/original//hPkqY2EMqWUnFEoedukilIUieVG.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//n1RohH2VoK1CdVI2fXvcP19dSlm.jpg",
+      "title": "The Outpost",
+      "average_rating": 3.8333333333333335,
+      "release_date": "2020-06-24"
+    },
+    {
+      "id": 499932,
+      "poster_path": "https://image.tmdb.org/t/p/original//7G2VvG1lU8q758uOqU6z2Ds0qpA.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//rUeqBuNDR9zN6vZV9kpEFMtQm0E.jpg",
+      "title": "The Devil All the Time",
+      "average_rating": 4.666666666666667,
+      "release_date": "2020-09-11"
+    },
+    {
+      "id": 413518,
+      "poster_path": "https://image.tmdb.org/t/p/original//4w1ItwCJCTtSi9nPfJC1vU6NIVg.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//AdqOBPw4PdtzOcfEuQuZ8MNeTKb.jpg",
+      "title": "Pinocchio",
+      "average_rating": 4.75,
+      "release_date": "2019-12-19"
+    },
+    {
+      "id": 577922,
+      "poster_path": "https://image.tmdb.org/t/p/original//k68nPLbIST6NP96JmTxmZijEvCA.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//wzJRB4MKi3yK138bJyuL9nx47y6.jpg",
+      "title": "Tenet",
+      "average_rating": 5.5,
+      "release_date": "2020-08-22"
+    },
+    {
+      "id": 619592,
+      "poster_path": "https://image.tmdb.org/t/p/original//ucktgbaMSaETUDLUBp1ubGD6aNj.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//eIqyISB5j99OSRZUuvdN9g2bBsS.jpg",
+      "title": "Force of Nature",
+      "average_rating": 4.4,
+      "release_date": "2020-07-02"
+    },
+    {
+      "id": 501979,
+      "poster_path": "https://image.tmdb.org/t/p/original//4V2nTPfeB59TcqJcUfQ9ziTi7VN.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//oazPqs1z78LcIOFslbKtJLGlueo.jpg",
+      "title": "Bill & Ted Face the Music",
+      "average_rating": 5,
+      "release_date": "2020-08-27"
+    },
+    {
+      "id": 340102,
+      "poster_path": "https://image.tmdb.org/t/p/original//xrI4EnZWftpo1B7tTvlMUXVOikd.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//eCIvqa3QVCx6H09bdeOS8Al2Sqy.jpg",
+      "title": "The New Mutants",
+      "average_rating": 4.2,
+      "release_date": "2020-08-26"
+    },
+    {
+      "id": 605499,
+      "poster_path": "https://image.tmdb.org/t/p/original//xIKVeH1iAKJOYYh9lvObD3hYIaf.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//48OhmVjmjqhB1TrevTMKwKUDetU.jpg",
+      "title": "Monsoon",
+      "average_rating": 5.25,
+      "release_date": "2020-09-25"
+    },
+    {
+      "id": 737568,
+      "poster_path": "https://image.tmdb.org/t/p/original//pklyUbh4k1DbHdnsOMASyw7C6NH.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//9pHxv7TX0jOKNgnGMDP6RJ2m1GL.jpg",
+      "title": "The Doorman",
+      "average_rating": 5.75,
+      "release_date": "2020-10-01"
+    },
+    {
+      "id": 400160,
+      "poster_path": "https://image.tmdb.org/t/p/original//gxK2lB1w8an5ViPXzisDsRsyHr0.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//bt4xA9WZE9P1wiRILRFt0Zh2wmV.jpg",
+      "title": "The SpongeBob Movie: Sponge on the Run",
+      "average_rating": 5.2,
+      "release_date": "2020-08-14"
+    },
+    {
+      "id": 579583,
+      "poster_path": "https://image.tmdb.org/t/p/original//zQFjMmE3K9AX5QrBL1SXIxYQ9jz.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//5rwcd24GGltKiqdPT4G2dmchLr9.jpg",
+      "title": "The King of Staten Island",
+      "average_rating": 6.8,
+      "release_date": "2020-07-22"
+    },
+    {
+      "id": 597398,
+      "poster_path": "https://image.tmdb.org/t/p/original//c59eplVELdwrUfGBUAZVin3HfaL.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//ccwPF5jN09S4Cz7u6qs3T2yKOpO.jpg",
+      "title": "Away",
+      "average_rating": 4.2,
+      "release_date": "2019-11-15"
+    },
+    {
+      "id": 617708,
+      "poster_path": "https://image.tmdb.org/t/p/original//yVsINl4Aa9vvQ9lE2LF77qNj7AP.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//oj9pEWQq5higRzKWiE8f0d5hBSb.jpg",
+      "title": "La llorona",
+      "average_rating": 4.5,
+      "release_date": "2020-01-22"
+    },
+    {
+      "id": 528085,
+      "poster_path": "https://image.tmdb.org/t/p/original//7D430eqZj8y3oVkLFfsWXGRcpEG.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//5UkzNSOK561c2QRy2Zr4AkADzLT.jpg",
+      "title": "2067",
+      "average_rating": 5.166666666666667,
+      "release_date": "2020-10-01"
+    },
+    {
+      "id": 610201,
+      "poster_path": "https://image.tmdb.org/t/p/original//jkAZb9jteax1XRnEFlCU9Oer1YJ.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//ruXHUA3KiiLEjCwvSqKuxe9O6ZQ.jpg",
+      "title": "The Pale Door",
+      "average_rating": 3,
+      "release_date": "2020-08-21"
+    },
+    {
+      "id": 550231,
+      "poster_path": "https://image.tmdb.org/t/p/original//5mCqEeBA0MW7H6akFrFQXJu68rU.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//zRc6SG8V8WTTDrmZ78PgqjwYqoN.jpg",
+      "title": "The Secret: Dare to Dream",
+      "average_rating": 5.6,
+      "release_date": "2020-04-16"
+    },
+    {
+      "id": 737173,
+      "poster_path": "https://image.tmdb.org/t/p/original//opZKcgocttEOAUzqluX3bUbbDew.jpg",
+      "backdrop_path": "https://www.esm.rochester.edu/uploads/NoPhotoAvailable.jpg",
+      "title": "Maratón After",
+      "average_rating": 4.333333333333333,
+      "release_date": "2020-09-03"
+    },
+    {
+      "id": 737799,
+      "poster_path": "https://image.tmdb.org/t/p/original//tEvGSlRO0dz1pINzjSEELdTHvwk.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//ysGikUSBjG3NRSyycHPf4rsIXQm.jpg",
+      "title": "Maquis",
+      "average_rating": 4.8,
+      "release_date": "2020-08-28"
+    },
+    {
+      "id": 500840,
+      "poster_path": "https://image.tmdb.org/t/p/original//5ynWWapdl45hJXUh0KIevxSG9JQ.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//x3NqAzuTWvnron4pXXyFGkyTFo7.jpg",
+      "title": "I'm Thinking of Ending Things",
+      "average_rating": 6,
+      "release_date": "2020-08-28"
+    },
+    {
+      "id": 547017,
+      "poster_path": "https://image.tmdb.org/t/p/original//iSwTnNS7TKAS79Sz9LvyqlBxxrU.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//97UR8xPpUNqpvx5zr7eyf4YSBCE.jpg",
+      "title": "Shirley",
+      "average_rating": 5.25,
+      "release_date": "2020-09-11"
+    },
+    {
+      "id": 449924,
+      "poster_path": "https://image.tmdb.org/t/p/original//swmjF0CQc59K3jdUFzOirXESeGN.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//hb3kjSQI0lwGUCIxnfAYec08VSq.jpg",
+      "title": "Ip Man 4: The Finale",
+      "average_rating": 6,
+      "release_date": "2019-12-19"
+    },
+    {
+      "id": 425001,
+      "poster_path": "https://image.tmdb.org/t/p/original//yUFbPtWeDbVR3zmqshOaL5lScyo.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//4gKyQ1McHa8ZKDsYoyKQSevF01J.jpg",
+      "title": "The War with Grandpa",
+      "average_rating": 5.666666666666667,
+      "release_date": "2020-01-31"
+    },
+    {
+      "id": 582885,
+      "poster_path": "https://image.tmdb.org/t/p/original//ow3OA6OC0rjgbMVaLn2drwjvqZE.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//6j2g4fEAmjJqAclzprIpvz9Gaw4.jpg",
+      "title": "Cuties",
+      "average_rating": 3.5,
+      "release_date": "2020-08-19"
+    },
+    {
+      "id": 659991,
+      "poster_path": "https://image.tmdb.org/t/p/original//erl30EcM8b8S84mvw8QXhNIeSfi.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//5nRyaVklxyA9OkxqZaPv1KBRqpd.jpg",
+      "title": "Made in Italy",
+      "average_rating": 5,
+      "release_date": "2020-08-06"
+    },
+    {
+      "id": 501953,
+      "poster_path": "https://image.tmdb.org/t/p/original//2wXrBtfrvwMWE1i3iHjKjoRZjYk.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//oeaLQKoPFQxvhEz3yyR1QuestXG.jpg",
+      "title": "Eternal Beauty",
+      "average_rating": 3,
+      "release_date": "2020-08-21"
+    },
+    {
+      "id": 585244,
+      "poster_path": "https://image.tmdb.org/t/p/original//dqA2FCzz4OMmXLitKopzf476RVB.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//21Q8bzu10YF9i4O5amBkJBombYo.jpg",
+      "title": "I Still Believe",
+      "average_rating": 3.8333333333333335,
+      "release_date": "2020-03-12"
+    }
+  ]
+};
+
+export default movieData;


### PR DESCRIPTION
This PR will create the main page showing all movies and a small header with a rough outline - the CSS still has perfecting to do. The structure is laid out in three components - app, movies and preview each with corresponding CSS files. 

closes #1 